### PR TITLE
Update checkout-go and checkout v2 -> v3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.14
+        go-version: ^1.19
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
# Why

Minimize notifications of deprecated components in GH Workflows. A handful will need to be outright replaced.

# What

* Bump go from 1.14 to 1.19.
* Bump checkout from v2 to v3.
* Bump setup-go from v2 to v3.
