### PR TITLE
Fix overflow bug

### DIFF
--- a/cmd/envcheckctl/exec_inspect.go
+++ b/cmd/envcheckctl/exec_inspect.go
@@ -107,6 +107,9 @@ func PrintTop(n int, header string, c cluster.Counter) {
 		return li[i].value > li[j].value
 	})
 	log.Println(header)
+	if n > len(li) {
+		n = len(li)
+	}
 	for _, v := range li[:n] {
 		log.Printf("- \"%v\"=%d", v.name, v.value)
 	}


### PR DESCRIPTION
# Why

Bug suck

# What

Fix an overflow bug in the PrintTop function with small node counts that should've been caught earlier.