### PR TITLE
Remove agentns flag from inspect

### DIFF
--- a/cmd/envcheckctl/envcheckctl_main.go
+++ b/cmd/envcheckctl/envcheckctl_main.go
@@ -91,7 +91,6 @@ func Parse(args []string, kubepath string, w io.Writer) (*EnvcheckConfig, error)
 	flags.BoolVar(&config.UseGateway, "use-gateway", false, "use the pods gateway as the host to ping")
 
 	flags, config = cmdFlags.FlagSet("inspect", InspectCluster)
-	flags.StringVar(&config.AgentNamespace, "agentns", "instana-agent", "Instana agent namespace")
 	flags.StringVar(&config.Podfile, "podfile", "", "read from podfile instead of live cluster query")
 	flags.StringVar(&config.Kubeconfig, "kubeconfig", kubepath, "absolute path to the kubeconfig file")
 

--- a/cmd/envcheckctl/envcheckctl_main_test.go
+++ b/cmd/envcheckctl/envcheckctl_main_test.go
@@ -43,8 +43,8 @@ func Test_parse_flags(t *testing.T) {
 		config *EnvcheckConfig
 	}{
 		"daemon":             {[]string{"envcheckctl", "daemon"}, &EnvcheckConfig{Subcommand: ApplyDaemon, AgentNamespace: "instana-agent"}},
-		"inspect":            {[]string{"envcheckctl", "inspect"}, &EnvcheckConfig{Subcommand: InspectCluster, AgentNamespace: "instana-agent"}},
-		"inspect offline":    {[]string{"envcheckctl", "inspect", "-podfile=foobar.json"}, &EnvcheckConfig{Subcommand: InspectCluster, AgentNamespace: "instana-agent", Podfile: "foobar.json"}},
+		"inspect":            {[]string{"envcheckctl", "inspect"}, &EnvcheckConfig{Subcommand: InspectCluster}},
+		"inspect offline":    {[]string{"envcheckctl", "inspect", "-podfile=foobar.json"}, &EnvcheckConfig{Subcommand: InspectCluster, Podfile: "foobar.json"}},
 		"ping":               {[]string{"envcheckctl", "ping"}, &EnvcheckConfig{Subcommand: ApplyPinger, PingerNamespace: "default"}},
 		"ping using gateway": {[]string{"envcheckctl", "ping", "-use-gateway"}, &EnvcheckConfig{Subcommand: ApplyPinger, PingerNamespace: "default", UseGateway: true}},
 		"leader":             {[]string{"envcheckctl", "leader"}, &EnvcheckConfig{Subcommand: Leader}},


### PR DESCRIPTION
# What

Remove agentns flag as it's unused in the inspect subcommand.

[KB-117070](https://instana.kanbanize.com/ctrl_board/140/cards/117070/details/)