### PR TITLE
Use contains instead of exact match for cniPlugins

### DIFF
--- a/cluster/index.go
+++ b/cluster/index.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // NewIndex builds a new empty index for PodInfo.
@@ -181,7 +182,13 @@ func IsCNIPlugin(n string) bool {
 		"sdn":         true,
 	}
 
-	return m[n]
+	for k := range m {
+		if strings.Contains(n, k) {
+			return true
+		}
+	}
+
+	return false
 }
 
 type Counter map[string]int

--- a/cluster/index_test.go
+++ b/cluster/index_test.go
@@ -143,3 +143,19 @@ func Test_Count_Pod_Status(t *testing.T) {
 	}
 	gunit.Number(t, index.PodStatus[""]).EqualTo(4)
 }
+
+func Test_IsCNIPlugin(t *testing.T) {
+	td := map[string]struct {
+		expected bool
+	}{
+		"instana-agent":         {false},
+		"kube-flannel-ds-kdwch": {true},
+		"aws-node":              {true},
+	}
+
+	for n, tc := range td {
+		t.Run(n, func(t *testing.T) {
+			gunit.Struct(t, cluster.IsCNIPlugin(n)).EqualTo(tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
# Why

Users can often rename the CNI Plugin DaemonSet which will break exact match.

# What

Use a string contains matching instead of exact match.